### PR TITLE
Ensure /todos endpoint returns empty list instead of nil

### DIFF
--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -7,7 +7,7 @@ type InMemory struct {
 }
 
 func NewInMemory() *InMemory {
-	return &InMemory{}
+	return &InMemory{todos: []entity.Todo{}}
 }
 
 func (r *InMemory) List() []entity.Todo {

--- a/internal/repository/in_memory_test.go
+++ b/internal/repository/in_memory_test.go
@@ -13,4 +13,8 @@ func TestList(t *testing.T) {
 	if len(todos) != 0 {
 		t.Errorf("expected 0 todos, got %d", len(todos))
 	}
+
+	if todos == nil {
+		t.Errorf("expected todos not to be nil")
+	}
 }


### PR DESCRIPTION
Related to #1

This pull request modifies the `NewInMemory` constructor and updates tests to ensure the `/todos` endpoint returns an empty list instead of nil when there are no todos.

- **Constructor Update**: Modifies the `NewInMemory` constructor in `internal/repository/in_memory.go` to explicitly initialize the `todos` slice as `[]entity.Todo{}`, ensuring it's never nil even when empty.
- **Test Enhancement**: Updates the test in `internal/repository/in_memory_test.go` to check that the `List` method returns an explicitly initialized empty slice, confirming it's not nil when there are no todos.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhturdav/golang-todo-list/issues/1?shareId=661fab92-6589-44c5-a69b-6577ac339801).