### PR TITLE
Ensure GET /todos returns empty list when no todos

### DIFF
--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -11,5 +11,9 @@ func NewInMemory() *InMemory {
 }
 
 func (r *InMemory) List() []entity.Todo {
+	if len(r.todos) == 0 {
+		return []entity.Todo{}
+	}
+
 	return r.todos
 }

--- a/internal/repository/in_memory_test.go
+++ b/internal/repository/in_memory_test.go
@@ -13,4 +13,8 @@ func TestList(t *testing.T) {
 	if len(todos) != 0 {
 		t.Errorf("expected 0 todos, got %d", len(todos))
 	}
+
+	if todos == nil {
+		t.Errorf("expected todos not to be nil")
+	}
 }


### PR DESCRIPTION
Related to #1

Fixes the issue where the `GET /todos` endpoint returned `null` instead of an empty list when there are no todos.
- Modifies `List()` in `internal/repository/in_memory.go` to explicitly return an empty slice of `entity.Todo` if `r.todos` is empty, ensuring the endpoint returns an empty list instead of `null`.
- Updates the test in `internal/repository/in_memory_test.go` to check that `List()` does not return `nil`, verifying the correct behavior when there are no todos.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhturdav/golang-todo-list/issues/1?shareId=c42c7e68-ac34-4f8f-a71e-2c8ac48d2259).