### PR TITLE
Add unit tests for internal/api package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.3
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -12,6 +13,7 @@ require (
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,0 +1,34 @@
+package api_test
+
+import (
+	"dhturdav/golang-todo-list/internal/api"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouter(t *testing.T) {
+	router := api.Router()
+
+	assert.NotNil(t, router, "Expected router to not be nil")
+}
+
+func TestTodosRouteRegistered(t *testing.T) {
+	router := api.Router()
+	req, _ := http.NewRequest("GET", "/todos", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Expected /todos route to be registered")
+}
+
+func TestTodosRouteReturnsEmptyList(t *testing.T) {
+	router := api.Router()
+	req, _ := http.NewRequest("GET", "/todos", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, "[]", w.Body.String(), "Expected /todos route to return an empty list")
+}


### PR DESCRIPTION
Related to #4

This pull request introduces unit tests for the `internal/api` package, enhancing the project's test coverage and ensuring the reliability of its routing and todo listing functionalities.

- **Adds unit tests for router functionality:**
  - Tests that the `Router()` function returns a non-nil `*gin.Engine` instance.
  - Verifies that the `/todos` route is correctly registered and accessible.
  - Ensures that the `/todos` route returns an empty list when no todos are present.

- **Updates project dependencies:**
  - Adds `github.com/stretchr/testify` to the project's dependencies to facilitate assertions in the newly introduced tests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhturdav/golang-todo-list/issues/4?shareId=06657d03-a5a3-4439-8cbc-154fd35b7cf7).