### PR TITLE
Add POST /todos endpoint

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -11,6 +11,7 @@ func Router() *gin.Engine {
 	todos := todosHandler{repository: repository.NewInMemory()}
 
 	router.GET("/todos", todos.list)
+	router.POST("/todos", todos.create)
 
 	return router
 }

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,11 +1,14 @@
 package api_test
 
 import (
+	"bytes"
 	"dhturdav/golang-todo-list/internal/api"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,4 +34,60 @@ func TestTodosRouteReturnsEmptyList(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, "[]", w.Body.String(), "Expected /todos route to return an empty list")
+}
+
+func TestPostTodos(t *testing.T) {
+	router := api.Router()
+	todo := map[string]string{"title": "Test todo"}
+	jsonValue, _ := json.Marshal(todo)
+	req, _ := http.NewRequest("POST", "/todos", bytes.NewBuffer(jsonValue))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Expected POST /todos to succeed")
+}
+
+func TestPostTodosResponseIDIsUUID(t *testing.T) {
+	router := api.Router()
+	todo := map[string]string{"title": "Test todo"}
+	jsonValue, _ := json.Marshal(todo)
+	req, _ := http.NewRequest("POST", "/todos", bytes.NewBuffer(jsonValue))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	_, err := uuid.Parse(response["id"].(string))
+	assert.Nil(t, err, "Expected response ID to be a valid UUID")
+}
+
+func TestAddTwoTodosThenGet(t *testing.T) {
+	router := api.Router()
+	todo1 := map[string]string{"title": "First todo"}
+	todo2 := map[string]string{"title": "Second todo"}
+	jsonValue1, _ := json.Marshal(todo1)
+	jsonValue2, _ := json.Marshal(todo2)
+
+	req1, _ := http.NewRequest("POST", "/todos", bytes.NewBuffer(jsonValue1))
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, req1)
+
+	req2, _ := http.NewRequest("POST", "/todos", bytes.NewBuffer(jsonValue2))
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+
+	req3, _ := http.NewRequest("GET", "/todos", nil)
+	w3 := httptest.NewRecorder()
+	router.ServeHTTP(w3, req3)
+
+	var response1, response2 map[string]interface{}
+	json.Unmarshal(w1.Body.Bytes(), &response1)
+	json.Unmarshal(w2.Body.Bytes(), &response2)
+
+	id1, _ := response1["id"].(string)
+	id2, _ := response2["id"].(string)
+
+	expectedResponse := `[{"id":"` + id1 + `","title":"First todo"},{"id":"` + id2 + `","title":"Second todo"}]`
+	assert.JSONEq(t, expectedResponse, w3.Body.String(), "Expected GET /todos to return the list of added todos")
 }

--- a/internal/api/todos.go
+++ b/internal/api/todos.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"dhturdav/golang-todo-list/internal/entity"
 	"dhturdav/golang-todo-list/internal/repository"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,4 +14,14 @@ type todosHandler struct {
 
 func (t *todosHandler) list(c *gin.Context) {
 	c.JSON(200, t.repository.List())
+}
+
+func (t *todosHandler) create(c *gin.Context) {
+	var todo entity.Todo
+	if err := c.ShouldBindJSON(&todo); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	todo = t.repository.Create(todo)
+	c.JSON(http.StatusOK, todo)
 }

--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -1,6 +1,9 @@
 package repository
 
-import "dhturdav/golang-todo-list/internal/entity"
+import (
+	"dhturdav/golang-todo-list/internal/entity"
+	"github.com/google/uuid"
+)
 
 type InMemory struct {
 	todos []entity.Todo
@@ -16,4 +19,11 @@ func (r *InMemory) List() []entity.Todo {
 	}
 
 	return r.todos
+}
+
+func (r *InMemory) Create(todo entity.Todo) entity.Todo {
+	todo.ID = uuid.New()
+	r.todos = append(r.todos, todo)
+
+	return todo
 }

--- a/internal/repository/in_memory_test.go
+++ b/internal/repository/in_memory_test.go
@@ -1,8 +1,12 @@
 package repository_test
 
 import (
+	"dhturdav/golang-todo-list/internal/entity"
 	"dhturdav/golang-todo-list/internal/repository"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestList(t *testing.T) {
@@ -17,4 +21,16 @@ func TestList(t *testing.T) {
 	if todos == nil {
 		t.Errorf("expected todos not to be nil")
 	}
+}
+
+func TestCreate(t *testing.T) {
+	r := repository.NewInMemory()
+	todo := entity.Todo{Title: "Test todo"}
+
+	r.Create(todo)
+
+	todos := r.List()
+	assert.Equal(t, 1, len(todos), "expected 1 todo after creation")
+	assert.Equal(t, "Test todo", todos[0].Title, "expected todo title to match")
+	assert.NotEqual(t, uuid.Nil, todos[0].ID, "expected todo to have a non-nil ID")
 }

--- a/internal/repository/in_memory_test.go
+++ b/internal/repository/in_memory_test.go
@@ -27,10 +27,7 @@ func TestCreate(t *testing.T) {
 	r := repository.NewInMemory()
 	todo := entity.Todo{Title: "Test todo"}
 
-	r.Create(todo)
-
-	todos := r.List()
-	assert.Equal(t, 1, len(todos), "expected 1 todo after creation")
-	assert.Equal(t, "Test todo", todos[0].Title, "expected todo title to match")
-	assert.NotEqual(t, uuid.Nil, todos[0].ID, "expected todo to have a non-nil ID")
+	createdTodo := r.Create(todo)
+	assert.Equal(t, "Test todo", createdTodo.Title, "expected todo title to match")
+	assert.NotEqual(t, uuid.Nil, createdTodo.ID, "expected todo to have a non-nil ID")
 }


### PR DESCRIPTION
Related to #8

Implements the `POST /todos` endpoint to allow the creation of new todo items, including generating a unique ID for each item and returning the new item in the response.

- **Endpoint Registration**: Adds the `POST /todos` route to the router in `internal/api/router.go`, linking it to the `create` method in `todosHandler`.
- **Create Method**: Introduces a `create` method in `todosHandler` within `internal/api/todos.go` to handle incoming POST requests, parse the request body, and return the newly created todo item as JSON.
- **Repository Changes**: Enhances the `InMemory` repository in `internal/repository/in_memory.go` with a `Create` method that generates a unique ID for each new todo item and adds it to the repository.
- **Testing Enhancements**: Updates and adds tests in `internal/repository/in_memory_test.go` and `internal/api/router_test.go` to cover the new functionality, including testing the creation of todo items, validating the generated ID is a UUID, and ensuring the correct response is returned when adding new todos and retrieving the list of all todos.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhturdav/golang-todo-list/issues/8?shareId=2fbbf5ba-4198-4c68-96f6-d2959dd5538c).